### PR TITLE
Make spec Ruby 1.8 compliant

### DIFF
--- a/spec/missing_key_spec.rb
+++ b/spec/missing_key_spec.rb
@@ -1,9 +1,9 @@
 describe Hash do
   it "should always know which keys are left" do
-    h = { a: 1, b: 2, c: 3 }
+    h = { :a => 1, :b => 2, :c => 3 }
     h.each do |k, v|
       h.delete :a
-      expect(h.keys).to eq [:b, :c]
+      expect(h.keys).to match_array [:b, :c]
     end
   end
 end


### PR DESCRIPTION
In order to run the code in Ruby 1.8, we have to use the old `:key => value` syntax.